### PR TITLE
Potential fix for code scanning alert no. 1: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/src/backend/routers/auth.py
+++ b/src/backend/routers/auth.py
@@ -4,7 +4,7 @@ Authentication endpoints for the High School Management System API
 
 from fastapi import APIRouter, HTTPException
 from typing import Dict, Any
-import hashlib
+from argon2 import PasswordHasher
 
 from ..database import teachers_collection
 
@@ -13,20 +13,25 @@ router = APIRouter(
     tags=["auth"]
 )
 
+ph = PasswordHasher()
+
 def hash_password(password):
-    """Hash password using SHA-256"""
-    return hashlib.sha256(password.encode()).hexdigest()
+    """Hash password using Argon2"""
+    return ph.hash(password)
 
 @router.post("/login")
 def login(username: str, password: str) -> Dict[str, Any]:
     """Login a teacher account"""
     # Hash the provided password
-    hashed_password = hash_password(password)
+    try:
+        ph.verify(teacher["password"], password)
+    except Exception:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
     
     # Find the teacher in the database
     teacher = teachers_collection.find_one({"_id": username})
     
-    if not teacher or teacher["password"] != hashed_password:
+    if not teacher:
         raise HTTPException(status_code=401, detail="Invalid username or password")
     
     # Return teacher information (excluding password)


### PR DESCRIPTION
Potential fix for [https://github.com/tomas99vogel/skills-introduction-to-repository-management/security/code-scanning/1](https://github.com/tomas99vogel/skills-introduction-to-repository-management/security/code-scanning/1)

To fix the issue, we will replace the use of SHA-256 with a secure password hashing algorithm. The `argon2-cffi` library will be used, as it provides a robust implementation of the Argon2 password hashing algorithm, which is computationally expensive and includes salting by default.

1. Replace the `hash_password` function with a new implementation using Argon2.
2. Update the `/login` endpoint to verify the password using Argon2's `verify` method instead of comparing raw hash values.
3. Add the necessary import for `PasswordHasher` from the `argon2` library.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
